### PR TITLE
更新wenaox1.30 多store对 controlA,controlB  methods的识别

### DIFF
--- a/dist/util.js
+++ b/dist/util.js
@@ -26,8 +26,8 @@ export const breakUpContros = c => {
   keys(c).forEach(i => {
     state[i] = assign(c[i].state, { loading: {} });
     methods[i] = {};
-    methods[i].syncs = c[i].syncs || {};
-    methods[i].asyncs = c[i].asyncs || {};
+    methods[i].syncs = c[i].methods.syncs || {};
+    methods[i].asyncs = c[i].methods.asyncs || {};
   });
   return { state, methods };
 };


### PR DESCRIPTION
wenaox1.30 有不识别controlA,controlB methods的问题，解决方法 utils.js breakUpContros () 函数里 c[i].syncs 要改成 c[i].methods.syncs